### PR TITLE
Pagination bug workaround

### DIFF
--- a/ilps/ilp.php
+++ b/ilps/ilp.php
@@ -41,7 +41,7 @@ $id = param_integer('id');
 
 // offset and limit for pagination
 $offset = param_integer('offset', 0);
-$limit = param_integer('limit', 20);
+$limit = param_integer('limit', 30);
 
 $ilp = new ArtefactTypeilp($id);
 if (!$USER->can_edit_artefact($ilp)) {

--- a/ilps/ilps.json.php
+++ b/ilps/ilps.json.php
@@ -32,7 +32,7 @@ define('JSON', 1);
 require(dirname(dirname(dirname(__FILE__))) . '/init.php');
 safe_require('artefact', 'ilps');
 
-$limit = param_integer('limit', 20);
+$limit = param_integer('limit', 30);
 $offset = param_integer('offset', 0);
 
 $ilps = ArtefactTypeIlp::get_ilps($offset, $limit);

--- a/ilps/index.php
+++ b/ilps/index.php
@@ -40,7 +40,7 @@ define('TITLE', get_string('myilps', 'artefact.ilps'));
 
 // offset and limit for pagination
 $offset = param_integer('offset', 0);
-$limit = param_integer('limit', 20);
+$limit = param_integer('limit', 30);
 
 $ilps = ArtefactTypeIlp::get_ilps($offset, $limit);
 ArtefactTypeIlp::build_ilps_list_html($ilps);

--- a/ilps/lib.php
+++ b/ilps/lib.php
@@ -311,7 +311,7 @@ class ArtefactTypeilp extends ArtefactType {
     public function render_self($options) {
         $this->add_to_render_path($options);
 
-        $limit = !isset($options['limit']) ? 20 : (int) $options['limit'];
+        $limit = !isset($options['limit']) ? 30 : (int) $options['limit'];
         $offset = isset($options['offset']) ? intval($options['offset']) : 0;
 
         $units = ArtefactTypeUnit::get_units($this->id, $offset, $limit);
@@ -652,7 +652,7 @@ class ArtefactTypeUnit extends ArtefactType {
      * @return array (grandtotalpoints: number, count: integer, data: array)
      * 
      */
-    public static function get_units($ilp, $offset = 0, $limit = 20) {
+    public static function get_units($ilp, $offset = 0, $limit = 30) {
 
         ($results = get_records_sql_array("
             SELECT a.id, at.artefact AS unit, at.status, at.points, " . db_format_tsfield('targetcompletion') . ", " . db_format_tsfield('datecompleted') . ",

--- a/ilps/units.json.php
+++ b/ilps/units.json.php
@@ -33,7 +33,7 @@ require(dirname(dirname(dirname(__FILE__))) . '/init.php');
 safe_require('artefact', 'ilps');
 
 $ilp = param_integer('id');
-$limit = param_integer('limit', 20);
+$limit = param_integer('limit', 30);
 $offset = param_integer('offset', 0);
 
 $units = ArtefactTypeUnit::get_units($ilp, $offset, $limit);

--- a/ilps/viewunits.json.php
+++ b/ilps/viewunits.json.php
@@ -35,7 +35,7 @@ require_once(get_config('docroot') . 'blocktype/lib.php');
 require_once(get_config('docroot') . 'artefact/ilps/blocktype/ilps/lib.php');
 
 $offset = param_integer('offset', 0);
-$limit = param_integer('limit', 20);
+$limit = param_integer('limit', 30);
 
 if ($blockid = param_integer('block', null)) {
     $bi = new BlockInstance($blockid);


### PR DESCRIPTION
When there are more than 20 units, the link to page 2 in the block is bad. Didn't find how to correct this for the moment, so I updated the number of units in a block from 20 to 30.